### PR TITLE
Switch case support

### DIFF
--- a/include/deferred/conditional.hpp
+++ b/include/deferred/conditional.hpp
@@ -75,6 +75,14 @@ public:
  *
  * The result type of <tt>if_then_else(...)()</tt> is the @c std::common_type of
  * the result types of @p then_ and @p else_.
+ *
+ * Example:
+ * @code
+ * auto v = variable<bool>();
+ * auto ex = if_then_else(v, constant(42), constant(10));
+ * v = true;
+ * assert(v() == 42);
+ * @endcode
  */
 template<typename IfExpression, typename ThenExpression, typename ElseExpression>
 constexpr auto

--- a/include/deferred/conditional.hpp
+++ b/include/deferred/conditional.hpp
@@ -29,14 +29,18 @@ template<typename IfExpression, typename ThenExpression, typename ElseExpression
 class if_then_else_ :
   private std::tuple<IfExpression, ThenExpression, ElseExpression>
 {
+private:
+  using subexpression_types =
+    std::tuple<IfExpression, ThenExpression, ElseExpression>;
+
 public:
   using constant_expression =
     std::conjunction<is_constant_expression<IfExpression>,
                      is_constant_expression<ThenExpression>,
                      is_constant_expression<ElseExpression>>;
-
-  using subexpression_types =
-    std::tuple<IfExpression, ThenExpression, ElseExpression>;
+  using result_type =
+    std::common_type_t<decltype(std::declval<ThenExpression>()()),
+                       decltype(std::declval<ElseExpression>()())>;
 
   template<typename IfEx, typename ThenEx, typename ElseEx>
   constexpr explicit if_then_else_(IfEx&& if_, ThenEx&& then_, ElseEx&& else_) :
@@ -46,7 +50,7 @@ public:
       std::forward<ElseEx>(else_))
   {}
 
-  constexpr decltype(auto) operator()() const
+  constexpr result_type operator()() const
   {
     if (std::get<0>(static_cast<subexpression_types const&>(*this))())
     {
@@ -68,6 +72,9 @@ public:
 /**
  * Creates a new deferred conditional that evaluates @p then_ if @p if_
  * evaluates to @c true, otherwise it evaluates @p else_.
+ *
+ * The result type of <tt>if_then_else(...)()</tt> is the @c std::common_type of
+ * the result types of @p then_ and @p else_.
  */
 template<typename IfExpression, typename ThenExpression, typename ElseExpression>
 constexpr auto

--- a/include/deferred/conditional.hpp
+++ b/include/deferred/conditional.hpp
@@ -65,18 +65,6 @@ public:
   }
 };
 
-namespace detail {
-
-// Transforms T into an expression_ if it is not a deferred data type for use
-// with if_then_else_.
-template<typename T>
-using make_conditional_expression_t = std::conditional_t<
-  is_deferred_v<T>,
-  T,
-  std::conditional_t<std::is_invocable_v<T>, make_expression_t<T>, constant_<T>>>;
-
-} // namespace detail
-
 /**
  * Creates a new deferred conditional that evaluates @p then_ if @p if_
  * evaluates to @c true, otherwise it evaluates @p else_.
@@ -85,9 +73,9 @@ template<typename IfExpression, typename ThenExpression, typename ElseExpression
 constexpr auto
 if_then_else(IfExpression&& if_, ThenExpression&& then_, ElseExpression&& else_)
 {
-  using if_expression   = detail::make_conditional_expression_t<IfExpression>;
-  using then_expression = detail::make_conditional_expression_t<ThenExpression>;
-  using else_expression = detail::make_conditional_expression_t<ElseExpression>;
+  using if_expression   = make_expression_t<IfExpression>;
+  using then_expression = make_expression_t<ThenExpression>;
+  using else_expression = make_expression_t<ElseExpression>;
   using expression_type =
     if_then_else_<if_expression, then_expression, else_expression>;
   return expression_type(std::forward<IfExpression>(if_),

--- a/include/deferred/deferred.hpp
+++ b/include/deferred/deferred.hpp
@@ -15,6 +15,7 @@
 #include "expression.hpp"
 #include "invoke.hpp"
 #include "operators.hpp"
+#include "switch.hpp"
 #include "variable.hpp"
 
 #endif

--- a/include/deferred/expression.hpp
+++ b/include/deferred/expression.hpp
@@ -76,18 +76,31 @@ namespace detail {
 
 // Transforms T into a constant_ if it is not a deferred data type.
 template<typename T>
-using make_expression_arg_t =
+using make_callable_arg_t =
   std::conditional_t<is_deferred_v<T>, T, constant_<T>>;
 
 } // namespace detail
 
-/// Transforms @p T into an @ref expression_ if it is not a deferred data type.
-template<typename T, typename... Args>
-using make_expression_t =
-  std::conditional_t<is_expression_v<T>,
-                     T,
-                     expression_<make_function_object_t<T>,
-                                 detail::make_expression_arg_t<Args>...>>;
+/**
+ * @brief Transforms @p Callable into an @ref expression_ if it is not a
+ * deferred data type.
+ */
+template<typename Callable, typename... Args>
+using make_callable_t =
+  std::conditional_t<is_expression_v<Callable>,
+                     Callable,
+                     expression_<make_function_object_t<Callable>,
+                                 detail::make_callable_arg_t<Args>...>>;
+
+/**
+ * @brief Transforms @p T into an @ref expression_ if it is not a deferred data
+ * type.
+ */
+template<typename T>
+using make_expression_t = std::conditional_t<
+  is_deferred_v<T>,
+  T,
+  std::conditional_t<std::is_invocable_v<T>, make_callable_t<T>, constant_<T>>>;
 
 } // namespace deferred
 

--- a/include/deferred/expression.hpp
+++ b/include/deferred/expression.hpp
@@ -60,7 +60,7 @@ public:
     return static_cast<Operator const&>(*this);
   }
 
-  subexpression_types const& subexpressions() const noexcept
+  decltype(auto) subexpressions() const noexcept
   {
     return static_cast<subexpression_types const&>(*this);
   }

--- a/include/deferred/invoke.hpp
+++ b/include/deferred/invoke.hpp
@@ -25,7 +25,7 @@ namespace deferred {
 template<typename F, typename... Args>
 constexpr auto invoke(F&& f, Args&&... args)
 {
-  using expression_type = make_expression_t<F, Args...>;
+  using expression_type = make_callable_t<F, Args...>;
   return expression_type(std::forward<F>(f), std::forward<Args>(args)...);
 }
 

--- a/include/deferred/switch.hpp
+++ b/include/deferred/switch.hpp
@@ -127,10 +127,9 @@ public:
       .compare(std::forward<T>(t));
   }
 
-  constexpr result_type operator()() const
+  template<typename T>
+  constexpr result_type choose_case(T&& t) const
   {
-    auto&& t = std::get<0>(static_cast<subexpression_types const&>(*this))();
-
     // TODO iterate over all
     if (compare<2>(t))
     {
@@ -143,6 +142,12 @@ public:
 
     // return default
     return std::get<1>(static_cast<subexpression_types const&>(*this))();
+  }
+
+  constexpr result_type operator()() const
+  {
+    return choose_case(
+      std::get<0>(static_cast<subexpression_types const&>(*this))());
   }
 
   template<typename Visitor>

--- a/include/deferred/switch.hpp
+++ b/include/deferred/switch.hpp
@@ -20,11 +20,90 @@
 
 namespace deferred {
 
-template<typename LabelExpression, typename CaseExpression>
-auto case_(LabelExpression&& label, CaseExpression&& body)
+/// Switch case expression.
+template<typename LabelExpression, typename BodyExpression>
+class case_expression : private std::tuple<LabelExpression, BodyExpression>
 {
-  using body_expression = make_expression_t<CaseExpression>;
-  return body_expression(std::forward<CaseExpression>(body));
+public:
+  using constant_expression =
+    std::conjunction<is_constant_expression<LabelExpression>,
+                     is_constant_expression<BodyExpression>>;
+
+  using subexpression_types = std::tuple<LabelExpression, BodyExpression>;
+
+  template<typename LabelEx, typename BodyEx>
+  constexpr explicit case_expression(LabelEx&& label, BodyEx&& body) :
+    std::tuple<LabelExpression, BodyExpression>(std::forward<LabelEx>(label),
+                                                std::forward<BodyEx>(body))
+  {}
+
+  /// Compares @p T with the label expression.
+  template<typename T>
+  constexpr bool compare(T&& t) const
+  {
+    return std::forward<T>(t)
+           == std::get<0>(static_cast<subexpression_types const&>(*this))();
+  }
+
+  /// Returns the result of the body expression.
+  constexpr decltype(auto) operator()() const
+  {
+    return std::get<1>(static_cast<subexpression_types const&>(*this))();
+  }
+
+  template<typename Visitor>
+  constexpr decltype(auto) visit(Visitor&& v) const
+  {
+    return std::forward<Visitor>(v)(*this);
+  }
+};
+
+/**
+ * Deferred switch
+ */
+template<typename SwitchExpression, typename... CaseExpression>
+class switch_expression :
+  private std::tuple<SwitchExpression, CaseExpression...>
+{
+public:
+  using constant_expression =
+    std::conjunction<is_constant_expression<SwitchExpression>,
+                     is_constant_expression<CaseExpression>...>;
+
+  using subexpression_types = std::tuple<SwitchExpression, CaseExpression...>;
+
+  template<typename SwitchEx, typename... CaseEx>
+  constexpr explicit switch_expression(SwitchEx&& sw, CaseEx&&... cs) :
+    std::tuple<SwitchExpression, CaseExpression...>(std::forward<SwitchEx>(sw),
+                                                    std::forward<CaseEx>(cs)...)
+  {}
+
+  constexpr decltype(auto) operator()() const
+  {
+    if (std::get<0>(static_cast<subexpression_types const&>(*this))())
+    {
+      return std::get<1>(static_cast<subexpression_types const&>(*this))();
+    }
+    else
+    {
+      return std::get<2>(static_cast<subexpression_types const&>(*this))();
+    }
+  }
+
+  template<typename Visitor>
+  constexpr decltype(auto) visit(Visitor&& v) const
+  {
+    return std::forward<Visitor>(v)(*this);
+  }
+};
+
+template<typename LabelExpression, typename BodyExpression>
+auto case_(LabelExpression&& label, BodyExpression&& body)
+{
+  using label_expression = make_expression_t<LabelExpression>;
+  using body_expression  = make_expression_t<BodyExpression>;
+  return case_expression<label_expression, body_expression>(
+    std::forward<LabelExpression>(label), std::forward<BodyExpression>(body));
 }
 
 template<typename Expression>

--- a/include/deferred/switch.hpp
+++ b/include/deferred/switch.hpp
@@ -1,0 +1,58 @@
+/** @file */
+/*
+ * Copyright (c) 2019 Yiannis Papadopoulos
+ *
+ * Distributed under the terms of the MIT License.
+ *
+ * (See accompanying file LICENSE or copy at http://opensource.org/licenses/MIT)
+ */
+
+#ifndef DEFERRED_SWITCH_HPP
+#define DEFERRED_SWITCH_HPP
+
+#include <type_traits>
+#include <utility>
+
+#include "constant.hpp"
+#include "expression.hpp"
+#include "type_traits/is_constant_expression.hpp"
+#include "type_traits/is_deferred.hpp"
+
+namespace deferred {
+
+namespace detail {
+
+// Transforms T into an expression_ if it is not a deferred data type for use
+// with if_then_else_.
+template<typename T>
+using make_switch_expression_t = std::conditional_t<
+  is_deferred_v<T>,
+  T,
+  std::conditional_t<std::is_invocable_v<T>, make_expression_t<T>, constant_<T>>>;
+
+} // namespace detail
+
+template<typename LabelExpression, typename CaseExpression>
+auto case_(LabelExpression&& label, CaseExpression&& body)
+{
+    using body_expression = detail::make_switch_expression_t<CaseExpression>;
+    return body_expression(std::forward<CaseExpression>(body));
+}
+
+template<typename Expression>
+auto default_(Expression&& ex)
+{
+    using expression = detail::make_switch_expression_t<Expression>;
+    return expression(std::forward<Expression>(ex));
+}
+
+template<typename SwitchExpression, typename... Expressions>
+auto switch_(SwitchExpression&& sw, Expressions&&... ex)
+{
+    using switch_expression = detail::make_switch_expression_t<SwitchExpression>;
+    return switch_expression(std::forward<SwitchExpression>(sw));
+}
+
+} // namespace deferred
+
+#endif

--- a/include/deferred/switch.hpp
+++ b/include/deferred/switch.hpp
@@ -20,37 +20,25 @@
 
 namespace deferred {
 
-namespace detail {
-
-// Transforms T into an expression_ if it is not a deferred data type for use
-// with if_then_else_.
-template<typename T>
-using make_switch_expression_t = std::conditional_t<
-  is_deferred_v<T>,
-  T,
-  std::conditional_t<std::is_invocable_v<T>, make_expression_t<T>, constant_<T>>>;
-
-} // namespace detail
-
 template<typename LabelExpression, typename CaseExpression>
 auto case_(LabelExpression&& label, CaseExpression&& body)
 {
-    using body_expression = detail::make_switch_expression_t<CaseExpression>;
-    return body_expression(std::forward<CaseExpression>(body));
+  using body_expression = make_expression_t<CaseExpression>;
+  return body_expression(std::forward<CaseExpression>(body));
 }
 
 template<typename Expression>
 auto default_(Expression&& ex)
 {
-    using expression = detail::make_switch_expression_t<Expression>;
-    return expression(std::forward<Expression>(ex));
+  using expression = make_expression_t<Expression>;
+  return expression(std::forward<Expression>(ex));
 }
 
 template<typename SwitchExpression, typename... Expressions>
 auto switch_(SwitchExpression&& sw, Expressions&&... ex)
 {
-    using switch_expression = detail::make_switch_expression_t<SwitchExpression>;
-    return switch_expression(std::forward<SwitchExpression>(sw));
+  using switch_expression = make_expression_t<SwitchExpression>;
+  return switch_expression(std::forward<SwitchExpression>(sw));
 }
 
 } // namespace deferred

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
   invoke.cpp
   main.cpp
   operators.cpp
+  switch.cpp
   variable.cpp
   variable_expressions.cpp)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
   main.cpp
   operators.cpp
   switch.cpp
+  switch_expressions.cpp
   variable.cpp
   variable_expressions.cpp)
 

--- a/test/conditional.cpp
+++ b/test/conditional.cpp
@@ -18,6 +18,14 @@ TEST_CASE("conditional with literal", "[conditional-literal]")
   CHECK(ex() == 42);
 }
 
+TEST_CASE("conditional with different result types", "[conditional-diff-types]")
+{
+  auto ex = deferred::if_then_else(true, 42, false);
+
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex() == 42);
+}
+
 TEST_CASE("conditional with lambda", "[conditional-lambdas]")
 {
   auto i  = 0;

--- a/test/switch.cpp
+++ b/test/switch.cpp
@@ -10,6 +10,26 @@
 
 #include "deferred/switch.hpp"
 
+TEST_CASE("case with literal", "[case-literal]")
+{
+  auto ex = deferred::case_(2, 0);  
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex.compare(1) == false);
+  CHECK(ex.compare(2) == true);
+  CHECK(ex() == 0);
+}
+
+TEST_CASE("case with lambda", "[case-lambda]")
+{
+  auto ex = deferred::case_([] { return 2; }, [] { return 0; });  
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex.compare(1) == false);
+  CHECK(ex.compare(2) == true);
+  CHECK(ex() == 0);
+}
+
+# if 0
+
 TEST_CASE("switch with literal", "[switch-literal]")
 {
   auto ex = deferred::switch_(2,
@@ -38,3 +58,5 @@ TEST_CASE("switch with case constants", "[switch-case-constant]")
   static_assert(deferred::is_constant_expression_v<decltype(ex)>);
   CHECK(ex() == 100);
 }
+
+#endif

--- a/test/switch.cpp
+++ b/test/switch.cpp
@@ -10,9 +10,23 @@
 
 #include "deferred/switch.hpp"
 
+TEST_CASE("default with literal", "[default-literal]")
+{
+  auto ex = deferred::default_(2);
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex() == 2);
+}
+
+TEST_CASE("default with lambda", "[default-lambda]")
+{
+  auto ex = deferred::default_([] { return false; });
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex() == false);
+}
+
 TEST_CASE("case with literal", "[case-literal]")
 {
-  auto ex = deferred::case_(2, 0);  
+  auto ex = deferred::case_(2, 0);
   static_assert(deferred::is_constant_expression_v<decltype(ex)>);
   CHECK(ex.compare(1) == false);
   CHECK(ex.compare(2) == true);
@@ -21,42 +35,53 @@ TEST_CASE("case with literal", "[case-literal]")
 
 TEST_CASE("case with lambda", "[case-lambda]")
 {
-  auto ex = deferred::case_([] { return 2; }, [] { return 0; });  
+  auto ex = deferred::case_([] { return 2; }, [] { return 0; });
   static_assert(deferred::is_constant_expression_v<decltype(ex)>);
   CHECK(ex.compare(1) == false);
   CHECK(ex.compare(2) == true);
   CHECK(ex() == 0);
 }
 
-# if 0
-
-TEST_CASE("switch with literal", "[switch-literal]")
+TEST_CASE("switch with two literals", "[switch-two-literals]")
 {
   auto ex = deferred::switch_(2,
+                              deferred::default_(100),
                               deferred::case_(1, [] { return 0; }),
                               deferred::case_(2, [] { return 10; }));
-
   static_assert(deferred::is_constant_expression_v<decltype(ex)>);
   CHECK(ex() == 10);
 }
 
-TEST_CASE("switch with literal and default", "[switch-literal-default]")
+TEST_CASE("switch with three literals", "[switch-three-literals]")
 {
   auto ex = deferred::switch_(3,
+                              deferred::default_(1000),
                               deferred::case_(1, [] { return 0; }),
                               deferred::case_(2, [] { return 10; }),
-                              deferred::default_([] { return 100; }));
-
+                              deferred::case_(3, [] { return 100; }));
   static_assert(deferred::is_constant_expression_v<decltype(ex)>);
   CHECK(ex() == 100);
 }
 
-TEST_CASE("switch with case constants", "[switch-case-constant]")
+TEST_CASE("switch with two literals defaulting",
+          "[switch-two-literals-default]")
 {
-  auto ex = deferred::switch_(3, 0, 10, 100);
-
+  auto ex = deferred::switch_(10,
+                              deferred::default_(100),
+                              deferred::case_(1, [] { return 0; }),
+                              deferred::case_(2, [] { return 10; }));
   static_assert(deferred::is_constant_expression_v<decltype(ex)>);
   CHECK(ex() == 100);
 }
 
-#endif
+TEST_CASE("switch with three literals defaulting",
+          "[switch-three-literals-default]")
+{
+  auto ex = deferred::switch_(0,
+                              deferred::default_(1000),
+                              deferred::case_(1, [] { return 0; }),
+                              deferred::case_(2, [] { return 10; }),
+                              deferred::case_(3, [] { return 100; }));
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex() == 1000);
+}

--- a/test/switch.cpp
+++ b/test/switch.cpp
@@ -12,11 +12,9 @@
 
 TEST_CASE("switch with literal", "[switch-literal]")
 {
-  auto ex =
-    deferred::switch_(
-      2,
-      deferred::case_(1, [] { return 0; }),
-      deferred::case_(2, [] { return 10; }));
+  auto ex = deferred::switch_(2,
+                              deferred::case_(1, [] { return 0; }),
+                              deferred::case_(2, [] { return 10; }));
 
   static_assert(deferred::is_constant_expression_v<decltype(ex)>);
   CHECK(ex() == 10);
@@ -24,12 +22,18 @@ TEST_CASE("switch with literal", "[switch-literal]")
 
 TEST_CASE("switch with literal and default", "[switch-literal-default]")
 {
-  auto ex =
-    deferred::switch_(
-      3,
-      deferred::case_(1, [] { return 0; }),
-      deferred::case_(2, [] { return 10; }),
-      deferred::default_([] { return 100; }));
+  auto ex = deferred::switch_(3,
+                              deferred::case_(1, [] { return 0; }),
+                              deferred::case_(2, [] { return 10; }),
+                              deferred::default_([] { return 100; }));
+
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex() == 100);
+}
+
+TEST_CASE("switch with case constants", "[switch-case-constant]")
+{
+  auto ex = deferred::switch_(3, 0, 10, 100);
 
   static_assert(deferred::is_constant_expression_v<decltype(ex)>);
   CHECK(ex() == 100);

--- a/test/switch.cpp
+++ b/test/switch.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Yiannis Papadopoulos
+ *
+ * Distributed under the terms of the MIT License.
+ *
+ * (See accompanying file LICENSE or copy at http://opensource.org/licenses/MIT)
+ */
+
+#include <catch2/catch.hpp>
+
+#include "deferred/switch.hpp"
+
+TEST_CASE("switch with literal", "[switch-literal]")
+{
+  auto ex =
+    deferred::switch_(
+      2,
+      deferred::case_(1, [] { return 0; }),
+      deferred::case_(2, [] { return 10; }));
+
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex() == 10);
+}
+
+TEST_CASE("switch with literal and default", "[switch-literal-default]")
+{
+  auto ex =
+    deferred::switch_(
+      3,
+      deferred::case_(1, [] { return 0; }),
+      deferred::case_(2, [] { return 10; }),
+      deferred::default_([] { return 100; }));
+
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex() == 100);
+}

--- a/test/switch_expressions.cpp
+++ b/test/switch_expressions.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019 Yiannis Papadopoulos
+ *
+ * Distributed under the terms of the MIT License.
+ *
+ * (See accompanying file LICENSE or copy at http://opensource.org/licenses/MIT)
+ */
+
+#include <cstring>
+
+#include <catch2/catch.hpp>
+
+#include "deferred/deferred.hpp"
+
+namespace {
+
+int foo()
+{
+  return 10;
+}
+
+} // namespace
+
+TEST_CASE("switch with constants", "[switch-constants]")
+{
+  auto c = deferred::constant(10);
+  auto ex =
+    deferred::switch_(c,
+                      deferred::default_(std::string("unknown")),
+                      deferred::case_(10, [] { return std::string("10"); }));
+
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex() == "10");
+
+  auto c2 = deferred::constant(ex);
+  CHECK(c2() == "10");
+}
+
+TEST_CASE("switch with c-strings", "[switch-c-strings]")
+{
+  auto var = deferred::variable<int>();
+  auto ex  = deferred::switch_(var,
+                              deferred::default_("unknown"),
+                              deferred::case_(10, [] { return "10"; }),
+                              deferred::case_(12, [] { return "12"; }));
+
+  static_assert(!deferred::is_constant_expression_v<decltype(ex)>);
+  var = 10;
+  CHECK(std::strcmp(ex(), "10") == 0);
+
+  var = 11;
+  CHECK(std::strcmp(ex(), "unknown") == 0);
+}
+
+TEST_CASE("switch checking against function", "[switch-function]")
+{
+  auto c  = deferred::constant(foo());
+  auto ex = deferred::switch_(
+    c,
+    deferred::default_(std::string("unknown")),
+    deferred::case_([] { return foo(); }, [] { return std::string("foo"); }));
+
+  static_assert(deferred::is_constant_expression_v<decltype(ex)>);
+  CHECK(ex() == "foo");
+}


### PR DESCRIPTION
Allows the use of switch-case expressions.

The difference between regular C++ switch-case and this is that in `deferred` you always need a `default` case.