### PR TITLE
Refactor constant

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,11 +8,14 @@ AlignConsecutiveDeclarations: false
 AlignEscapedNewlinesLeft: Left
 AlignOperands: true
 AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
@@ -21,6 +24,7 @@ BinPackArguments: false
 BinPackParameters: false
 BreakBeforeBraces: Custom
 BraceWrapping:
+  AfterCaseLabel: true
   AfterClass: true
   AfterControlStatement: true
   AfterEnum: true
@@ -38,7 +42,6 @@ BraceWrapping:
   SplitEmptyNamespace: false
 BreakAfterJavaFieldAnnotations: false
 BreakBeforeBinaryOperators: NonAssignment
-BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
@@ -79,6 +82,7 @@ ReflowComments: true
 SortIncludes: true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: false

--- a/include/deferred/constant.hpp
+++ b/include/deferred/constant.hpp
@@ -30,7 +30,7 @@ private:
 
 public:
   /// Constructs a constant_ from @p u.
-  template<typename U, std::enable_if_t<std::is_convertible_v<U, T>>* = {}>
+  template<typename U, std::enable_if_t<std::is_convertible_v<U, T>>* = nullptr>
   constexpr explicit constant_(U&& u) : m_t(std::forward<U>(u))
   {}
 
@@ -63,14 +63,14 @@ public:
 namespace detail {
 
 // Returns t.
-template<typename T, std::enable_if_t<!std::is_invocable_v<T>>* = {}>
+template<typename T, std::enable_if_t<!std::is_invocable_v<T>>* = nullptr>
 constexpr decltype(auto) recursive_eval(T&& t) noexcept
 {
   return std::forward<T>(t);
 }
 
 // Returns the result of t().
-template<typename T, std::enable_if_t<std::is_invocable_v<T>>* = {}>
+template<typename T, std::enable_if_t<std::is_invocable_v<T>>* = nullptr>
 constexpr auto recursive_eval(T&& t)
 {
   return recursive_eval(std::forward<T>(t)());

--- a/include/deferred/constant.hpp
+++ b/include/deferred/constant.hpp
@@ -30,7 +30,7 @@ private:
 
 public:
   /// Constructs a constant_ from @p u.
-  template<typename U, std::enable_if_t<std::is_convertible_v<U, T>>* = nullptr>
+  template<typename U, std::enable_if_t<std::is_convertible_v<U, T>>* = {}>
   constexpr explicit constant_(U&& u) : m_t(std::forward<U>(u))
   {}
 
@@ -59,42 +59,37 @@ public:
   }
 };
 
-/**
- * Creates a new @ref constant_ that is initialized from a constant expression.
- *
- * @warning This function will force <tt>ex()</tt>.
- */
-template<typename Expression,
-         std::enable_if_t<
-           is_deferred_v<Expression> && is_constant_expression_v<Expression>>* =
-           nullptr>
-constexpr auto constant(Expression&& ex)
+
+namespace detail {
+
+// Returns t.
+template<typename T, std::enable_if_t<!std::is_invocable_v<T>>* = {}>
+constexpr decltype(auto) recursive_eval(T&& t) noexcept
 {
-  using internal_type = std::decay_t<decltype(std::forward<Expression>(ex)())>;
-  return constant_<internal_type>(std::forward<Expression>(ex)());
+  return std::forward<T>(t);
 }
 
-/// Creates a new @ref constant_ that is initialized with @p t.
-template<
-  typename T,
-  std::enable_if_t<!is_deferred_v<T> && !std::is_invocable_v<T>>* = nullptr>
+// Returns the result of t().
+template<typename T, std::enable_if_t<std::is_invocable_v<T>>* = {}>
+constexpr auto recursive_eval(T&& t)
+{
+  return recursive_eval(std::forward<T>(t)());
+}
+
+} // namespace detail
+
+/**
+ * Creates a constant for use in @c deferred expressions.
+ *
+ * If @p t is a callable type, this function will force its evaluation through
+ * <tt>t()</tt>. This applies even if @p t is a @c deferred expression.
+ */
+template<typename T>
 constexpr auto constant(T&& t)
 {
-  using internal_type = std::decay_t<T>;
-  return constant_<internal_type>(std::forward<T>(t));
-}
-
-/**
- * Creates a new @ref constant_ that is initialized from a callable @p f.
- *
- * @warning This function will force <tt>f()</tt>.
- */
-template<typename F,
-         std::enable_if_t<!is_deferred_v<F> && std::is_invocable_v<F>>* = nullptr>
-constexpr auto constant(F&& f)
-{
-  using internal_type = decltype(std::forward<F>(f)());
-  return constant_<internal_type>(std::forward<F>(f)());
+  using result_type =
+    std::decay_t<decltype(detail::recursive_eval(std::forward<T>(t)))>;
+  return constant_<result_type>(detail::recursive_eval(std::forward<T>(t)));
 }
 
 } // namespace deferred

--- a/test/integration/constant.cpp
+++ b/test/integration/constant.cpp
@@ -45,15 +45,10 @@ TEST_CASE("constant from chained constant expressions",
   CHECK(ex3() == 0);
 }
 
-#if 0
-// cannot create constant from expression with variable
-TEST_CASE("constant from expression with variable",
-          "[constant-from-non-constant-expression]")
+TEST_CASE("constant from expression with variable", "[constant-from-variable]")
 {
   auto v  = deferred::variable(2);
   auto ex = deferred::constant(4) * v;
   auto c  = deferred::constant(ex);
   CHECK(c() == 8);
-  FAIL("Cannot create constant from expression with a variable");
 }
-#endif

--- a/test/unit/constant.cpp
+++ b/test/unit/constant.cpp
@@ -16,24 +16,31 @@ TEST_CASE("constant from lvalue", "[constantf-from-lvalue]")
 {
   auto const i = 4;
   auto c       = deferred::constant(i);
+
+  static_assert(deferred::is_constant_expression_v<decltype(c)>);
   CHECK(c() == i);
 
   SECTION("constexpr")
   {
     constexpr auto c2 = deferred::constant(i);
-    CHECK(c2() == 4);
+    static_assert(deferred::is_constant_expression_v<decltype(c2)>);
     static_assert(c2() == 4, "constexpr failed");
+    CHECK(c2() == 4);
   }
 }
 
 TEST_CASE("constant from prvalue", "[constant-from-prvalue]")
 {
   auto c = deferred::constant(4);
+
+  static_assert(deferred::is_constant_expression_v<decltype(c)>);
   CHECK(c() == 4);
 
   SECTION("constexpr")
   {
     constexpr auto c2 = deferred::constant(4);
+
+    static_assert(deferred::is_constant_expression_v<decltype(c2)>);
     CHECK(c2() == 4);
     static_assert(c2() == 4, "constexpr failed");
   }
@@ -44,6 +51,8 @@ TEST_CASE("constant from xvalue", "[constant-from-xvalue]")
   std::vector<int> v = {1, 2, 3};
   auto const v2      = v;
   auto c             = deferred::constant(std::move(v));
+
+  static_assert(deferred::is_constant_expression_v<decltype(c)>);
   CHECK(c() == v2);
 }
 
@@ -51,6 +60,7 @@ TEST_CASE("constant from constant", "[constant-from-constant]")
 {
   constexpr auto c1 = deferred::constant(4);
   constexpr auto c2 = deferred::constant(c1);
+
   static_assert(std::is_same_v<decltype(c1), decltype(c2)>,
                 "copy created nested type");
   static_assert(c2() == 4, "constexpr failed");
@@ -60,10 +70,10 @@ TEST_CASE("constant from constant", "[constant-from-constant]")
 TEST_CASE("constant from lambda", "[constant-from-lambda]")
 {
   auto i = 0;
-  auto c = deferred::constant([&i]() mutable { return ++i; });
-  CHECK(i == 1);
+  auto c = deferred::constant([&i] { return ++i; });
 
   static_assert(deferred::is_constant_expression_v<decltype(c)>);
+  CHECK(i == 1);
   CHECK(c() == 1);
   CHECK(c() == 1);
 }
@@ -91,5 +101,23 @@ TEST_CASE("constant from function", "[constant-from-function]")
   auto c = deferred::constant(&function);
 
   static_assert(deferred::is_constant_expression_v<decltype(c)>);
+  CHECK(c() == 10);
+}
+
+namespace {
+
+  constexpr int function2()
+  {
+    return 10;
+  }
+
+} // namespace
+
+TEST_CASE("constant from constexpr function", "[constant-from-constexpr-function]")
+{
+  constexpr auto c = deferred::constant(&function2);
+
+  static_assert(deferred::is_constant_expression_v<decltype(c)>);
+  static_assert(c() == 10, "constexpr failed");
   CHECK(c() == 10);
 }

--- a/test/unit/constant.cpp
+++ b/test/unit/constant.cpp
@@ -95,6 +95,15 @@ TEST_CASE("constant from nested lambda", "[constant-nested-lambda]")
   CHECK(c() == 10);
 }
 
+TEST_CASE("constant from nested lambda constant",
+          "[constant-nested-lambda-constant]")
+{
+  auto c = deferred::constant([] { return deferred::constant(10); });
+
+  static_assert(deferred::is_constant_expression_v<decltype(c)>);
+  CHECK(c() == 10);
+}
+
 namespace {
 
 int function()
@@ -114,14 +123,15 @@ TEST_CASE("constant from function", "[constant-from-function]")
 
 namespace {
 
-  constexpr int function2()
-  {
-    return 10;
-  }
+constexpr int function2()
+{
+  return 10;
+}
 
 } // namespace
 
-TEST_CASE("constant from constexpr function", "[constant-from-constexpr-function]")
+TEST_CASE("constant from constexpr function",
+          "[constant-from-constexpr-function]")
 {
   constexpr auto c = deferred::constant(&function2);
 

--- a/test/unit/constant.cpp
+++ b/test/unit/constant.cpp
@@ -12,7 +12,7 @@
 
 #include <vector>
 
-TEST_CASE("constant from lvalue", "[constantf-from-lvalue]")
+TEST_CASE("constant from lvalue", "[constant-lvalue]")
 {
   auto const i = 4;
   auto c       = deferred::constant(i);
@@ -29,7 +29,7 @@ TEST_CASE("constant from lvalue", "[constantf-from-lvalue]")
   }
 }
 
-TEST_CASE("constant from prvalue", "[constant-from-prvalue]")
+TEST_CASE("constant from prvalue", "[constant-prvalue]")
 {
   auto c = deferred::constant(4);
 
@@ -46,7 +46,7 @@ TEST_CASE("constant from prvalue", "[constant-from-prvalue]")
   }
 }
 
-TEST_CASE("constant from xvalue", "[constant-from-xvalue]")
+TEST_CASE("constant from xvalue", "[constant-xvalue]")
 {
   std::vector<int> v = {1, 2, 3};
   auto const v2      = v;
@@ -56,7 +56,7 @@ TEST_CASE("constant from xvalue", "[constant-from-xvalue]")
   CHECK(c() == v2);
 }
 
-TEST_CASE("constant from constant", "[constant-from-constant]")
+TEST_CASE("constant from constant", "[constant-nested-constant]")
 {
   constexpr auto c1 = deferred::constant(4);
   constexpr auto c2 = deferred::constant(c1);
@@ -67,7 +67,7 @@ TEST_CASE("constant from constant", "[constant-from-constant]")
   CHECK(c2() == 4);
 }
 
-TEST_CASE("constant from lambda", "[constant-from-lambda]")
+TEST_CASE("constant from lambda", "[constant-lambda]")
 {
   auto i = 0;
   auto c = deferred::constant([&i] { return ++i; });
@@ -78,13 +78,21 @@ TEST_CASE("constant from lambda", "[constant-from-lambda]")
   CHECK(c() == 1);
 }
 
-TEST_CASE("constant from mutable lambda", "[constant-from-mutable-lambda]")
+TEST_CASE("constant from mutable lambda", "[constant-mutable-lambda]")
 {
   auto c = deferred::constant([i = 0]() mutable { return ++i; });
 
   static_assert(deferred::is_constant_expression_v<decltype(c)>);
   CHECK(c() == 1);
   CHECK(c() == 1);
+}
+
+TEST_CASE("constant from nested lambda", "[constant-nested-lambda]")
+{
+  auto c = deferred::constant([] { return [] { return 10; }; });
+
+  static_assert(deferred::is_constant_expression_v<decltype(c)>);
+  CHECK(c() == 10);
 }
 
 namespace {


### PR DESCRIPTION
`constant()` now evaluates recursively the expression.